### PR TITLE
TStatistic image must be resliced on underlay file

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@ SELECT ?filename ?location WHERE \
                    console.log(niifiles2load)
 
                     var params = [];
-                    params["worldSpace"] = false;
+                    params["worldSpace"] = true;
                     params["expandable"] = true;
                     //params["kioskMode"] = true;
                     getQueryParams(params);


### PR DESCRIPTION
If TStatistic.nii.gz is not resliced on the underlay file, the files are not properly displayed:

Original T-Statistic file:
![screen shot 2014-11-15 at 21 06 23](https://cloud.githubusercontent.com/assets/5374264/5060088/4f7d0f7a-6d0b-11e4-841b-ea1b2a64976d.png)

Resliced T-Statistic file:
![image](https://cloud.githubusercontent.com/assets/5374264/5060092/8ca5bb72-6d0b-11e4-97ac-b3938365885f.png)

Another possibility to solve this issue would be to share an underaly file in the nidm archive.
